### PR TITLE
Fix getConfigsRootDir

### DIFF
--- a/index.js
+++ b/index.js
@@ -267,7 +267,7 @@ BemConfig.prototype.moduleSync = function(moduleName) {
 };
 
 function getConfigsRootDir(configs) {
-    var rootCfg = configs.find(function(cfg) { return cfg.root && cfg.__source; });
+    var rootCfg = [].concat(configs).reverse().find(function(cfg) { return cfg.root && cfg.__source; });
     if (rootCfg) { return path.dirname(rootCfg.__source); }
 }
 

--- a/test/sync.js
+++ b/test/sync.js
@@ -49,6 +49,16 @@ test('should return project root', t => {
     t.deepEqual(bemConfig().rootSync(), path.dirname(__filename));
 });
 
+test('should respect proper project root', t => {
+    const bemConfig = config([
+        { test: 1, root: true, __source: 'some/path' },
+        { test: 2, root: true, __source: __filename },
+        { other: 'field', __source: 'some/other/path' }
+    ]);
+
+    t.deepEqual(bemConfig().rootSync(), path.dirname(__filename));
+});
+
 // get()
 test('should return merged config', t => {
     const bemConfig = config([


### PR DESCRIPTION
```
parent-dir/
    .bemrc # with root: true
    project-dir/
        .bemrc # with root: true
        # cwd for bem-config, without this change parent-dir is considered to be root dir
```